### PR TITLE
Add capability to support configuration

### DIFF
--- a/src/main/java/io/dropwizard/websockets/WebsocketBundleConfiguration.java
+++ b/src/main/java/io/dropwizard/websockets/WebsocketBundleConfiguration.java
@@ -1,0 +1,30 @@
+/**
+ * The MIT License
+ * Copyright (c) 2017 LivePerson, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.dropwizard.websockets;
+
+
+public interface WebsocketBundleConfiguration {
+
+    WebsocketConfiguration getWebsocketConfiguration();
+
+}

--- a/src/main/java/io/dropwizard/websockets/WebsocketConfiguration.java
+++ b/src/main/java/io/dropwizard/websockets/WebsocketConfiguration.java
@@ -1,0 +1,85 @@
+/**
+ * The MIT License
+ * Copyright (c) 2017 LivePerson, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.dropwizard.websockets;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.util.Duration;
+import io.dropwizard.util.Size;
+import io.dropwizard.validation.MinDuration;
+import io.dropwizard.validation.MinSize;
+
+public class WebsocketConfiguration {
+
+    @MinDuration(0L)
+    private Duration maxSessionIdleTimeout;
+
+    @MinDuration(0L)
+    private Duration asyncSendTimeout;
+
+    @MinSize(1L)
+    private Size maxBinaryMessageBufferSize;
+
+    @MinSize(1L)
+    private Size maxTextMessageBufferSize;
+
+    @JsonProperty
+    public Duration getMaxSessionIdleTimeout() {
+        return maxSessionIdleTimeout;
+    }
+
+    @JsonProperty
+    public void setMaxSessionIdleTimeout(Duration maxSessionIdleTimeout) {
+        this.maxSessionIdleTimeout = maxSessionIdleTimeout;
+    }
+
+    @JsonProperty
+    public Duration getAsyncSendTimeout() {
+        return asyncSendTimeout;
+    }
+
+    @JsonProperty
+    public void setAsyncSendTimeout(Duration asyncSendTimeout) {
+        this.asyncSendTimeout = asyncSendTimeout;
+    }
+
+    @JsonProperty
+    public Size getMaxBinaryMessageBufferSize() {
+        return maxBinaryMessageBufferSize;
+    }
+
+    @JsonProperty
+    public void setMaxBinaryMessageBufferSize(Size maxBinaryMessageBufferSize) {
+        this.maxBinaryMessageBufferSize = maxBinaryMessageBufferSize;
+    }
+
+    @JsonProperty
+    public Size getMaxTextMessageBufferSize() {
+        return maxTextMessageBufferSize;
+    }
+
+    @JsonProperty
+    public void setMaxTextMessageBufferSize(Size maxTextMessageBufferSize) {
+        this.maxTextMessageBufferSize = maxTextMessageBufferSize;
+    }
+
+}

--- a/src/test/java/io/dropwizard/websockets/DropWizardWebsocketsTest.java
+++ b/src/test/java/io/dropwizard/websockets/DropWizardWebsocketsTest.java
@@ -25,11 +25,6 @@ package io.dropwizard.websockets;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.io.Resources;
-import java.io.IOException;
-import java.net.URI;
-import java.util.concurrent.CountDownLatch;
-import static java.util.concurrent.TimeUnit.SECONDS;
-import javax.websocket.Session;
 import junit.framework.Assert;
 import org.apache.http.client.config.RequestConfig;
 import org.apache.http.client.methods.HttpGet;
@@ -42,10 +37,17 @@ import org.glassfish.tyrus.client.ClientManager;
 import org.glassfish.tyrus.client.ClientProperties;
 import org.glassfish.tyrus.ext.client.java8.SessionBuilder;
 import org.junit.After;
-import static org.junit.Assert.*;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
+
+import javax.websocket.Session;
+import java.io.IOException;
+import java.net.URI;
+import java.util.concurrent.CountDownLatch;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.junit.Assert.assertTrue;
 
 public class DropWizardWebsocketsTest {
     @BeforeClass

--- a/src/test/java/io/dropwizard/websockets/MyApp.java
+++ b/src/test/java/io/dropwizard/websockets/MyApp.java
@@ -27,7 +27,6 @@ import com.codahale.metrics.annotation.Metered;
 import com.codahale.metrics.annotation.Timed;
 import com.codahale.metrics.health.HealthCheck;
 import io.dropwizard.Application;
-import io.dropwizard.Configuration;
 import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import org.eclipse.jetty.util.component.AbstractLifeCycle;
@@ -47,7 +46,7 @@ import java.security.NoSuchAlgorithmException;
 import java.security.spec.InvalidKeySpecException;
 import java.util.concurrent.CountDownLatch;
 
-public class MyApp extends Application<Configuration> {
+public class MyApp extends Application<MyAppConfiguration> {
     private final CountDownLatch cdl;
 
     MyApp(CountDownLatch cdl) {
@@ -55,15 +54,15 @@ public class MyApp extends Application<Configuration> {
     }
 
     @Override
-    public void initialize(Bootstrap<Configuration> bootstrap) {
-        websocketBundle = new WebsocketBundle(AnnotatedEchoServer.class);
+    public void initialize(Bootstrap<MyAppConfiguration> bootstrap) {
+        websocketBundle = new WebsocketBundle<MyAppConfiguration>(AnnotatedEchoServer.class);
         bootstrap.addBundle(websocketBundle);
     }
 
     private WebsocketBundle websocketBundle;
 
     @Override
-    public void run(Configuration configuration, Environment environment) throws InvalidKeySpecException, NoSuchAlgorithmException, ServletException, DeploymentException {
+    public void run(MyAppConfiguration configuration, Environment environment) throws InvalidKeySpecException, NoSuchAlgorithmException, ServletException, DeploymentException {
         environment.lifecycle().addLifeCycleListener(new AbstractLifeCycle.AbstractLifeCycleListener() {
 
             @Override
@@ -74,8 +73,8 @@ public class MyApp extends Application<Configuration> {
         environment.jersey().register(new MyResource());
         environment.healthChecks().register("alive", new HealthCheck() {
             @Override
-            protected HealthCheck.Result check() throws Exception {
-                return HealthCheck.Result.healthy();
+            protected Result check() throws Exception {
+                return Result.healthy();
             }
         });
 

--- a/src/test/java/io/dropwizard/websockets/MyAppConfiguration.java
+++ b/src/test/java/io/dropwizard/websockets/MyAppConfiguration.java
@@ -1,0 +1,46 @@
+/**
+ * The MIT License
+ * Copyright (c) 2017 LivePerson, Inc.
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package io.dropwizard.websockets;
+
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.dropwizard.Configuration;
+
+import javax.validation.Valid;
+
+public class MyAppConfiguration extends Configuration implements WebsocketBundleConfiguration {
+
+    @Valid
+    private WebsocketConfiguration websocketConfiguration = new WebsocketConfiguration();
+
+    @Override
+    @JsonProperty("websockets")
+    public WebsocketConfiguration getWebsocketConfiguration() {
+        return websocketConfiguration;
+    }
+
+    @JsonProperty("websockets")
+    public void setWebsocketConfiguration(WebsocketConfiguration websocketConfiguration) {
+        this.websocketConfiguration = websocketConfiguration;
+    }
+}

--- a/src/test/resources/server.yml
+++ b/src/test/resources/server.yml
@@ -5,3 +5,6 @@ server:
   adminConnectors:
     - type: http
       port: 48081
+
+websockets:
+  maxSessionIdleTimeout: 100s


### PR DESCRIPTION
We are leveraging this project to easily set up web socket server end point. We have found the connection between web socket server and client will automatically drop when there is no activity for five minutes. The five minutes is the default idle timeout setting in jetty web socket implementation. We are required to make the persistent connection once the connection is established. Connection dropping means something goes wrong on either server or client side. We want to prevent this automatically disconnect by introducing configuration.
Please let me know if this is considered a valid request.