### PR TITLE
~ update dependencies (dropwizard 1.3.10, jetty 9.4.18)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <dropwizard.version>1.3.14</dropwizard.version>
-        <jetty.version>9.4.18.v20190429</jetty.version>
+        <jetty.version>9.4.20.v20190813</jetty.version>
         <tyrus.version>1.15</tyrus.version>
     </properties>
     <artifactId>dropwizard-websockets</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -2,13 +2,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.liveperson</groupId>
-    <version>1.3.2</version>
+    <version>1.3.10</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <dropwizard.version>1.3.2</dropwizard.version>
-        <jetty.version>9.4.10.v20180503</jetty.version>
+        <dropwizard.version>1.3.10</dropwizard.version>
+        <jetty.version>9.4.18.v20190429</jetty.version>
+        <tyrus.version>1.15</tyrus.version>
     </properties>
     <artifactId>dropwizard-websockets</artifactId>
     <packaging>jar</packaging>
@@ -48,7 +49,6 @@
         </dependencies>
     </dependencyManagement>
     <dependencies>
-
         <dependency>
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-core</artifactId>
@@ -76,7 +76,7 @@
         <dependency>
             <groupId>org.glassfish.tyrus.ext</groupId>
             <artifactId>tyrus-client-java8</artifactId>
-            <version>1.12</version>
+            <version>${tyrus.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -88,7 +88,7 @@
         <dependency>
             <groupId>org.glassfish.tyrus</groupId>
             <artifactId>tyrus-container-grizzly-client</artifactId>
-            <version>1.12</version>
+            <version>${tyrus.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -114,7 +114,7 @@
             <plugin>
                 <groupId>org.sonatype.plugins</groupId>
                 <artifactId>nexus-staging-maven-plugin</artifactId>
-                <version>1.6.6</version>
+                <version>1.6.8</version>
                 <extensions>true</extensions>
                 <configuration>
                     <serverId>ossrh</serverId>
@@ -125,7 +125,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.4</version>
+                <version>3.0.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -138,7 +138,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.3</version>
+                <version>3.1.0</version>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -2,12 +2,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.liveperson</groupId>
-    <version>1.3.10</version>
+    <version>1.3.14</version>
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
-        <dropwizard.version>1.3.10</dropwizard.version>
+        <dropwizard.version>1.3.14</dropwizard.version>
         <jetty.version>9.4.18.v20190429</jetty.version>
         <tyrus.version>1.15</tyrus.version>
     </properties>
@@ -16,7 +16,7 @@
     <inceptionYear>2017</inceptionYear>
     <name>Dropwizard Websocket Support</name>
     <description>3rd party bundle for dropwizard to enable websocket services.</description>
-    <url>https://github.com/LivePersonInc/dropwizard-websockets</url>
+    <url>https://github.com/black-snow/dropwizard-websockets</url>
     <licenses>
         <license>
             <name>The MIT License (MIT)</name>
@@ -33,9 +33,9 @@
         </developer>
     </developers>
     <scm>
-        <url>https://github.com/LivePersonInc/dropwizard-websockets</url>
-        <connection>scm:git:https://github.com/LivePersonInc/dropwizard-websockets.git</connection>
-        <developerConnection>scm:git:https://github.com/LivePersonInc/dropwizard-websockets.git</developerConnection>
+        <url>https://github.com/black-snow/dropwizard-websockets</url>
+        <connection>scm:git:https://github.com/black-snow/dropwizard-websockets.git</connection>
+        <developerConnection>scm:git:https://github.com/black-snow/dropwizard-websockets.git</developerConnection>
     </scm>
     <dependencyManagement>
         <dependencies>

--- a/src/main/java/io/dropwizard/websockets/GeneralUtils.java
+++ b/src/main/java/io/dropwizard/websockets/GeneralUtils.java
@@ -24,8 +24,6 @@ package io.dropwizard.websockets;
 
 import java.util.function.Consumer;
 import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 public class GeneralUtils {
     


### PR DESCRIPTION
* upgrade dropwizard from 1.3.2 -> 1.3.10
* update version number to 1.3.10 (to reflect the dw version)
* upgrade jetty from 9.4.10 -> 9.4.18
* upgrade jetty from 1.12 -> 1.15
* upgrade nexus-staging-maven-plugin from 1.6.6 -> 1.6.8
* upgrade maven-source-plugin from 2.4 -> 3.0.1
* upgrade maven-javadoc-plugin from 2.10.3 -> 3.1.0